### PR TITLE
Encode Unicode to UTF-8

### DIFF
--- a/natsrv.py
+++ b/natsrv.py
@@ -6,7 +6,7 @@ def _get_nonce():
 	return os.urandom(NONCE_LEN).encode('hex')
 
 def _hash(str):
-	return hashlib.sha256(str).hexdigest()
+	return hashlib.sha256(str.encode('utf-8')).hexdigest()
 
 def _format_addr(addr):
 	ip, port = addr


### PR DESCRIPTION
Had to do this or following readme.md would spit out this error 
```
Traceback (most recent call last):
  File "natsrv.py", line 252, in <module>
    srv = NATSrv(args.secret, adminip, int(adminport), clientip, int(clientport)
)
  File "natsrv.py", line 133, in __init__
    self.hashlen = len(_hash(""))
  File "natsrv.py", line 9, in _hash
    return hashlib.sha256(str).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```